### PR TITLE
Add test for diffX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 node_modules
 
 lib/index.js
+lib/index.js.map
 lib/index.map

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -115,6 +115,16 @@ testRandomOp = (type, genRandomOp, initialDoc = type.create()) ->
 
     testDiff set for set in opSets when doc.ops.length > 0
 
+  if type.diffX?
+    testDiffX = (doc) ->
+      [ op1_, op2_ ] = type.diffX initialDoc, doc.result
+      result1 = type.apply clone(doc.result), op1_
+      result2 = type.apply clone(initialDoc), op2_
+      checkSnapshotsEq result1, initialDoc
+      checkSnapshotsEq result2, doc.result
+
+    testDiffX set for set in opSets
+
   # If all the ops are composed together, then applied, we should get the same result.
   if type.compose?
     p 'COMPOSE'


### PR DESCRIPTION
# Spec

`diffX` takes 2 document snapshots and returns 2 sets of operations, which can be applied to turn one snapshot into the other and vice versa. (It's like [diff in rich-text](https://github.com/ottypes/rich-text/blob/master/lib/type.js#L26), however, it returns 2 deltas, instead of one.) It satisfies the following equations:

`[ delta1, delta2 ] = type.diffX(snapshot1, snapshot2)` => `type.apply(snapshot1, delta2) == snapshot2` and `type.apply(snapshot2, delta1) == snapshot1`.

# Use Case

I have implemented an OT type for which I can compute 2 deltas at once more efficiently, then calculating 2 deltas separately. The application using the OT type always needs both deltas: one for the "forward" action and one for the "undo".