### PR TITLE
Fix 'doc is not defined'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -90,8 +90,9 @@ const testRandomOp = function(type, genRandomOp, initialDoc = type.create()) {
   const opSets = ([0, 1, 2].map(() => makeDoc()));
   const [client, client2, server] = opSets;
 
+  let doc;
   for (let i = 0; i < 10; i++) {
-    const doc = opSets[randomInt(3)];
+    doc = opSets[randomInt(3)];
     let [op, newDoc] = genRandomOp(doc.result)
     if (type.makeInvertible) op = type.makeInvertible(op, doc.result)
     doc.result = newDoc

--- a/test/count.js
+++ b/test/count.js
@@ -24,6 +24,10 @@ const count = {
     if ((op1[0] + op1[1]) !== op2[0]) { throw new Error(`Op1 ${op1} + 1 != op2 ${op2}`); }
     return [op1[0], op1[1] + op2[1]];
   },
+
+  diff(snapshot1, snapshot2) {
+    return [snapshot1, snapshot2 - snapshot1];
+  },
 }
 
 


### PR DESCRIPTION
👋 Hi! This is a fix for an undefined `doc` variable introduced in the recent coffeescript cleanup. It only occurs when `diff` is being fuzzed, so I added an implementation to the test type too.

Here's this bug when running the fuzzer on `rich-text`:

```
Exception has occurred: ReferenceError: doc is not defined
  at testRandomOp (/Users/john/code/jahewson/rich-text/node_modules/ot-fuzzer/lib/index.js:149:5)
    at module.exports (/Users/john/code/jahewson/rich-text/node_modules/ot-fuzzer/lib/index.js:335:13)
    at /Users/john/code/jahewson/rich-text/test/fuzzer.js:150:7
    at Proxy.assertThrows (/Users/john/code/jahewson/rich-text/node_modules/chai/lib/chai/core/assertions.js:2630:7)
    at Proxy.methodWrapper (/Users/john/code/jahewson/rich-text/node_modules/chai/lib/chai/utils/addMethod.js:57:25)
    at Context.<anonymous> (/Users/john/code/jahewson/rich-text/test/fuzzer.js:151:20)
    at callFn (/Users/john/code/jahewson/rich-text/node_modules/mocha/lib/runnable.js:387:21)
    at Test.Runnable.run (/Users/john/code/jahewson/rich-text/node_modules/mocha/lib/runnable.js:379:7)
    at Runner.runTest (/Users/john/code/jahewson/rich-text/node_modules/mocha/lib/runner.js:535:10)
    at /Users/john/code/jahewson/rich-text/node_modules/mocha/lib/runner.js:653:12
    at next (/Users/john/code/jahewson/rich-text/node_modules/mocha/lib/runner.js:447:14)
    at /Users/john/code/jahewson/rich-text/node_modules/mocha/lib/runner.js:457:7
    at next (/Users/john/code/jahewson/rich-text/node_modules/mocha/lib/runner.js:362:14)
    at Immediate._onImmediate (/Users/john/code/jahewson/rich-text/node_modules/mocha/lib/runner.js:425:5)
    at processImmediate (internal/timers.js:456:21)
    at process.callbackTrampoline (internal/async_hooks.js:120:14)
```

Thanks!